### PR TITLE
fix(npm): package.json に name を明記し worktree での lockfile 差分を防ぐ

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "fix-5",
+  "name": "dotfiles",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "dotfiles",
       "devDependencies": {
         "prettier": "^3.8.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "dotfiles",
   "private": true,
   "scripts": {
     "format": "prettier --write '**/*.md'",


### PR DESCRIPTION
## 概要

`package-lock.json` に `"name": "fix-5"` が混入していたため修正します。

## 原因

`package.json` に `name` フィールドが無く、npm が**ディレクトリ名**を lockfile の `name` に採用していました。#6 の作業を worktree（ディレクトリ名 `fix-5`）で行い、そこで `npm install` した結果 `"name": "fix-5"` が生成され、そのままコミットに含まれていました。

## 変更内容

- `package.json` に `"name": "dotfiles"` を明記
- `package-lock.json` を再生成（`fix-5` → `dotfiles`）

これにより、worktree を含むどのディレクトリで `npm install` しても lockfile に差分が出なくなります。

## テストプラン

```
npm install               → package-lock.json の name が dotfiles になることを確認
npm run format:check      → 通過
shellcheck *.sh lib/*.sh ai/rules/*.sh → 警告なし
```

Refs #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)